### PR TITLE
Fix XML comments and update docfx generation

### DIFF
--- a/NumeralSystems.Net/NumeralSystems.Net/Numeral.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Numeral.cs
@@ -12,7 +12,6 @@ using Convert = System.Convert;
 namespace NumeralSystems.Net
 {
     /// Represents a numeral in a specific numeral system.
-    /// /
     public class Numeral
     {
         // ReSharper disable once MemberCanBePrivate.Global
@@ -507,7 +506,12 @@ namespace NumeralSystems.Net
                 /// </summary>
                 public const char Minus = '-';
 
-                /// *Remarks:**
+                /// <summary>
+                /// Represents the semicolon character (;).
+                /// </summary>
+                /// <remarks>
+                /// Used to separate items in numeral formats.
+                /// </remarks>
                 public const char Semicolon = ';';
             }
 

--- a/NumeralSystems.Net/NumeralSystems.Net/Utils/Math/And.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Utils/Math/And.cs
@@ -10,12 +10,13 @@ namespace NumeralSystems.Net.Utils
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
     internal static partial class Math
     {
+        /// <summary>
         /// Performs a bitwise AND operation on two boolean arrays.
-        /// @param a The first boolean array.
-        /// @param b The second boolean array.
-        /// @return The result of the bitwise AND operation as a boolean array.
-        /// @throws ArgumentException if the lengths of the input arrays are not equal.
-        /// /
+        /// </summary>
+        /// <param name="a">The first boolean array.</param>
+        /// <param name="b">The second boolean array.</param>
+        /// <returns>The result of the bitwise AND operation as a boolean array.</returns>
+        /// <exception cref="ArgumentException">Thrown when the input arrays are not of equal length.</exception>
         public static bool[] And(this bool[] a, bool[] b)
         {
             if (a.Length != b.Length) throw new ArgumentException("Arrays must be of equal length");
@@ -43,12 +44,13 @@ namespace NumeralSystems.Net.Utils
             return result;
         }
 
+        /// <summary>
         /// Performs the logical AND operation on two boolean arrays and returns the result.
-        /// Throws an ArgumentException if the arrays are not of equal length.
-        /// @param a - The first boolean array.
-        /// @param b - The second boolean array.
-        /// @return The result of the logical AND operation as a boolean array.
-        /// /
+        /// </summary>
+        /// <remarks>Throws an <see cref="ArgumentException"/> if the arrays are not of equal length.</remarks>
+        /// <param name="a">The first boolean array.</param>
+        /// <param name="b">The second boolean array.</param>
+        /// <returns>The result of the logical AND operation as a boolean array.</returns>
         public static bool?[] And(this bool[] a, bool?[] b)
         {
             if (a.Length != b.Length) throw new ArgumentException("Arrays must be of equal length");


### PR DESCRIPTION
## Summary
- clean up stray documentation comments in `Numeral.cs`
- add summary and remarks for the `Semicolon` constant
- replace `@param` style docs with XML comments in `Utils/Math/And.cs`
- verified docs build via `docfx`

## Testing
- `docfx docfx.json`
- `dotnet test NumeralSystems.Net/NumeralSystems.Net.sln` *(fails: framework 5.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f01a06184832cb01623fda0343612