### PR TITLE
Add English README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,25 @@
+# NumeralSystems.Net
+
+NumeralSystems.Net is a .NET library that lets you work with values expressed in
+arbitrary numeral systems. It provides types for parsing, converting and
+manipulating numbers using custom bases. The library includes:
+
+- **Value** and **NumeralValue**: store numeric data with a specified base and
+  support base conversion.
+- **Numeral** and **NumeralSystem**: represent full numeral systems and offer
+  parsing utilities.
+- Wrappers for primitives like `Byte`, `Char`, `Int`, `Long`, `Float` and
+  `Double` with additional bitwise operations.
+- Utility methods for counting permutations, combinations and grouping
+  sequences.
+
+To build or run the tests, move into the `NumeralSystems.Net` folder and use:
+
+```bash
+cd NumeralSystems.Net
+DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet restore
+DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet build
+DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet test
+```
+
+Documentation can be generated with `docfx build`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[English README](README.en.md)
 Il progetto `NumeralSystems.Net` contiene due classi principali che gestiscono valori numerici rappresentati in diversi sistemi numerici. Ecco una panoramica delle classi `Value` e `NumeralValue` e delle loro funzionalità.
 #### Classe `Value`
 La classe `Value` rappresenta un valore numerico in un sistema numerico specifico, con una base definita. Include:


### PR DESCRIPTION
## Summary
- add an English README with an overview in `README.en.md`
- link to the English version from the Italian README

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f48e1e8dc832cbaff060121bb4163