### PR TITLE
Fix IncompleteDecimal OR operations

### DIFF
--- a/NumeralSystems.Net/NumeralSystem.Net.NUnit/Type/Incomplete/IncompleteDecimal.cs
+++ b/NumeralSystems.Net/NumeralSystem.Net.NUnit/Type/Incomplete/IncompleteDecimal.cs
@@ -1,0 +1,65 @@
+using NUnit.Framework;
+using NumeralSystems.Net.Type.Base;
+using NumeralSystems.Net.Type.Incomplete;
+using System.Linq;
+
+namespace NumeralSystem.Net.NUnit.Type.Incomplete
+{
+    [TestFixture]
+    public class IncompleteDecimalTests
+    {
+        private static bool? Or(bool? left, bool right)
+        {
+            if (left is null)
+                return right ? true : (bool?)null;
+            return left.Value || right;
+        }
+
+        private static bool? Or(bool? left, bool? right)
+        {
+            return (left, right) switch
+            {
+                (null, null) => null,
+                (false, null) => null,
+                (true, null) => true,
+                (null, false) => null,
+                (null, true) => true,
+                (false, false) => false,
+                (false, true) => true,
+                (true, false) => true,
+                (true, true) => true,
+            };
+        }
+
+        private static bool?[] Or(bool?[] left, bool[] right)
+            => left.Select((l, i) => Or(l, right[i])).ToArray();
+
+        private static bool?[] Or(bool?[] left, bool?[] right)
+            => left.Select((l, i) => Or(l, right[i])).ToArray();
+
+        [Test]
+        public void OrWithDecimal()
+        {
+            var baseLeft = new Decimal { Value = 1m };
+            var baseRight = new Decimal { Value = 2m };
+            var left = baseLeft.Incomplete();
+            left.Binary[0] = null; // introduce an unknown bit
+            var expected = Or(left.Binary.ToArray(), baseRight.Binary);
+            var result = left.Or(baseRight);
+            Assert.That(result.Binary, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void OrWithIncompleteDecimal()
+        {
+            var baseLeft = new Decimal { Value = 1m };
+            var baseRight = new Decimal { Value = 2m };
+            var left = baseLeft.Incomplete();
+            var right = baseRight.Incomplete();
+            right.Binary[1] = null; // introduce an unknown bit
+            var expected = Or(left.Binary.ToArray(), right.Binary.ToArray());
+            var result = left.Or(right);
+            Assert.That(result.Binary, Is.EqualTo(expected));
+        }
+    }
+}

--- a/NumeralSystems.Net/NumeralSystems.Net/Type/Base/Decimal.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Type/Base/Decimal.cs
@@ -3,32 +3,32 @@ using System.Linq;
 using NumeralSystems.Net.Interface;
 using NumeralSystems.Net.Type.Incomplete;
 using Math = NumeralSystems.Net.Utils.Math;
+using Convert = Polecola.Primitive.Convert;
 
 namespace NumeralSystems.Net.Type.Base
 {
-    /* TODO: Implement Decimal
     public partial class Decimal: IRegularOperable<IncompleteDecimal, Decimal, decimal, ulong>
     {
         public static Decimal FromBinary(bool[] binary) => new ()
         {
-            Value = Utils.Convert.ToDecimal(binary)
+            Value = Convert.ToDecimal(binary)
         };
         
         public virtual decimal Value { get; set; }
         
         public byte[] Bytes
         {
-            get => Utils.Convert.ToByteArray(Value);
+            get => Convert.ToByteArray(Value);
             // ReSharper disable once UnusedMember.Local
-            set => Value = value.Length >= sizeof(decimal) ? Utils.Convert.ToDecimal(value) : Utils.Convert.ToDecimal(value.Concat(System.Linq.Enumerable.Repeat((byte)0, sizeof(decimal) - value.Length)).ToArray());
+            set => Value = value.Length >= sizeof(decimal) ? Convert.ToDecimal(value) : Convert.ToDecimal(value.Concat(System.Linq.Enumerable.Repeat((byte)0, sizeof(decimal) - value.Length)).ToArray());
         }
 
         public int BitLength => sizeof(decimal) * 8;
 
         public bool[] Binary
         {
-            get => Utils.Convert.ToBoolArray(Value);
-            set => Value = value.Length * 8 >= sizeof(decimal) ?  Utils.Convert.ToDecimal(value) : Utils.Convert.ToDecimal(value.Concat(System.Linq.Enumerable.Repeat(false, sizeof(decimal)*8 - value.Length*8)).ToArray());
+            get => Convert.ToBoolArray(Value);
+            set => Value = value.Length * 8 >= sizeof(decimal) ?  Convert.ToDecimal(value) : Convert.ToDecimal(value.Concat(System.Linq.Enumerable.Repeat(false, sizeof(decimal)*8 - value.Length*8)).ToArray());
         }
         
         public bool this[int index]
@@ -151,5 +151,4 @@ namespace NumeralSystems.Net.Type.Base
 
         public string ToString(string format) => Value.ToString(format);
     }
-    */
 }

--- a/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteDecimal.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteDecimal.cs
@@ -4,12 +4,12 @@ using System.Linq;
 using NumeralSystems.Net.Interface;
 using NumeralSystems.Net.Utils;
 using Math = NumeralSystems.Net.Utils.Math;
+using Polecola.Primitive;
 using Convert = Polecola.Primitive.Convert;
 using Decimal = NumeralSystems.Net.Type.Base.Decimal;
 
 namespace NumeralSystems.Net.Type.Incomplete
 {
-    /* TODO: Implement IncompleteDecimal
     public class IncompleteDecimal: IIRregularOperable<IncompleteDecimal, Decimal, decimal, ulong>
     {
         private bool?[] _binary;
@@ -78,7 +78,7 @@ namespace NumeralSystems.Net.Type.Incomplete
         public string ToString(string missingSeparator = "*") => string.Join(string.Empty, Binary.Group(8).Select(x => x.Reverse().ToArray()).SelectMany(x => x).Select(x => null == x ? missingSeparator : (x.Value ? 1 : 0).ToString()));
         public IncompleteDecimal Or(Decimal other) => new()
         {
-            Binary = Binary.And(other.Binary)
+            Binary = Binary.Or(other.Binary)
         };
 
         public bool Contains(Decimal value)
@@ -128,7 +128,7 @@ namespace NumeralSystems.Net.Type.Incomplete
 
         public IncompleteDecimal Or(IncompleteDecimal other) => new()
         {
-            Binary = Binary.And(other.Binary)
+            Binary = Binary.Or(other.Binary)
         };
 
         public bool ReverseAnd(Decimal right, out IncompleteDecimal result)
@@ -187,5 +187,4 @@ namespace NumeralSystems.Net.Type.Incomplete
             return true;
         }
     }
-    */
 }


### PR DESCRIPTION
## Summary
- implement Decimal base type and IncompleteDecimal
- correct `Or` logic to use `Binary.Or`
- add unit tests for IncompleteDecimal OR methods

## Testing
- `dotnet test NumeralSystems.Net/NumeralSystem.Net.NUnit/NumeralSystem.Net.NUnit.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684f49716230832ca332321441e51690