### PR TITLE
Remove obsolete TODO comment

### DIFF
--- a/NumeralSystems.Net/NumeralSystems.Net/Numeral.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Numeral.cs
@@ -464,8 +464,6 @@ namespace NumeralSystems.Net
                 public static IEnumerable<char> AlphanumericSymbols =
                     Numbers.Concat(UpperLetters).Concat(LowerLetters)
                         .Concat(Symbols);
-
-                //TODO: Remove duplicates
                 /// <summary>
                 /// The set of printable characters.
                 /// </summary>


### PR DESCRIPTION
## Summary
- remove outdated comment from `Numeral.cs`

## Testing
- `dotnet test NumeralSystems.Net/NumeralSystems.Net.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4d34dcd4832c828727464cba7d29