### PR TITLE
Add advanced incomplete bitwise operations

### DIFF
--- a/NumeralSystems.Net/NumeralSystem.Net.NUnit/Type/Incomplete/IncompleteByteOperations.cs
+++ b/NumeralSystems.Net/NumeralSystem.Net.NUnit/Type/Incomplete/IncompleteByteOperations.cs
@@ -1,0 +1,34 @@
+using NumeralSystems.Net.Type.Base;
+using NumeralSystems.Net.Type.Incomplete;
+using NumeralSystems.Net.Utils;
+using NUnit.Framework;
+
+namespace NumeralSystem.Net.NUnit.Type.Incomplete
+{
+    [TestFixture]
+    public class IncompleteByteOperations
+    {
+        [Test]
+        public void NandNorXnor()
+        {
+            var left = new IncompleteByte { Binary = new bool?[] { true, null, false, false, false, false, false, false } };
+            var right = new Byte { Value = 1 };
+            var expectedNand = left.Binary.Nand(right.Binary);
+            var expectedNor = left.Binary.Nor(right.Binary);
+            var expectedXnor = left.Binary.Xnor(right.Binary);
+            Assert.That(left.Nand(right).Binary, Is.EqualTo(expectedNand));
+            Assert.That(left.Nor(right).Binary, Is.EqualTo(expectedNor));
+            Assert.That(left.Xnor(right).Binary, Is.EqualTo(expectedXnor));
+        }
+
+        [Test]
+        public void ShiftLeftRight()
+        {
+            var left = new IncompleteByte { Binary = new bool?[] { true, false, false, false, false, false, false, false } };
+            var expectedLeft = left.Binary.ShiftLeft(1);
+            var expectedRight = left.Binary.ShiftRight(1);
+            Assert.That(left.ShiftLeft(1).Binary, Is.EqualTo(expectedLeft));
+            Assert.That(left.ShiftRight(1).Binary, Is.EqualTo(expectedRight));
+        }
+    }
+}

--- a/NumeralSystems.Net/NumeralSystems.Net/Interface/IIRregularOperable.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Interface/IIRregularOperable.cs
@@ -55,6 +55,54 @@
         /// <returns>Bitwise or on the second parameter</returns>
         TIncomplete Or(TValue other);
         /// <summary>
+        /// Bitwise nand operation.
+        /// </summary>
+        /// <param name="other">Second parameter of the operation</param>
+        /// <returns>Bitwise nand on the second parameter</returns>
+        TIncomplete Nand(TIncomplete other);
+        /// <summary>
+        /// Bitwise nand operation.
+        /// </summary>
+        /// <param name="other">Second parameter of the operation</param>
+        /// <returns>Bitwise nand on the second parameter</returns>
+        TIncomplete Nand(TValue other);
+        /// <summary>
+        /// Bitwise nor operation.
+        /// </summary>
+        /// <param name="other">Second parameter of the operation</param>
+        /// <returns>Bitwise nor on the second parameter</returns>
+        TIncomplete Nor(TIncomplete other);
+        /// <summary>
+        /// Bitwise nor operation.
+        /// </summary>
+        /// <param name="other">Second parameter of the operation</param>
+        /// <returns>Bitwise nor on the second parameter</returns>
+        TIncomplete Nor(TValue other);
+        /// <summary>
+        /// Bitwise xnor operation.
+        /// </summary>
+        /// <param name="other">Second parameter of the operation</param>
+        /// <returns>Bitwise xnor on the second parameter</returns>
+        TIncomplete Xnor(TIncomplete other);
+        /// <summary>
+        /// Bitwise xnor operation.
+        /// </summary>
+        /// <param name="other">Second parameter of the operation</param>
+        /// <returns>Bitwise xnor on the second parameter</returns>
+        TIncomplete Xnor(TValue other);
+        /// <summary>
+        /// Shifts the bits to the left.
+        /// </summary>
+        /// <param name="count">Number of bits to shift</param>
+        /// <returns>The shifted incomplete value</returns>
+        TIncomplete ShiftLeft(int count);
+        /// <summary>
+        /// Shifts the bits to the right.
+        /// </summary>
+        /// <param name="count">Number of bits to shift</param>
+        /// <returns>The shifted incomplete value</returns>
+        TIncomplete ShiftRight(int count);
+        /// <summary>
         /// Checks if the incomplete value contains the given value.
         /// </summary>
         /// <param name="value">The value to check</param>

--- a/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteByte.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteByte.cs
@@ -215,6 +215,46 @@ namespace NumeralSystems.Net.Type.Incomplete
             Binary = Binary.Or(other.Binary)
         };
 
+        public IncompleteByte Nand(IncompleteByte other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteByte Nand(Byte other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteByte Nor(IncompleteByte other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteByte Nor(Byte other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteByte Xnor(IncompleteByte other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteByte Xnor(Byte other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteByte ShiftLeft(int count) => new()
+        {
+            Binary = Binary.ShiftLeft(count)
+        };
+
+        public IncompleteByte ShiftRight(int count) => new()
+        {
+            Binary = Binary.ShiftRight(count)
+        };
+
         /// <summary>
         /// Performs a reverse bitwise AND operation with the specified byte.
         /// </summary>

--- a/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteChar.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteChar.cs
@@ -211,6 +211,46 @@ namespace NumeralSystems.Net.Type.Incomplete
             Binary = Binary.Or(other.Binary)
         };
 
+        public IncompleteChar Nand(IncompleteChar other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteChar Nand(Char other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteChar Nor(IncompleteChar other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteChar Nor(Char other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteChar Xnor(IncompleteChar other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteChar Xnor(Char other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteChar ShiftLeft(int count) => new()
+        {
+            Binary = Binary.ShiftLeft(count)
+        };
+
+        public IncompleteChar ShiftRight(int count) => new()
+        {
+            Binary = Binary.ShiftRight(count)
+        };
+
         /// <summary>
         /// Performs a reverse bitwise AND operation with the specified character.
         /// </summary>

--- a/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteDecimal.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteDecimal.cs
@@ -131,6 +131,46 @@ namespace NumeralSystems.Net.Type.Incomplete
             Binary = Binary.Or(other.Binary)
         };
 
+        public IncompleteDecimal Nand(IncompleteDecimal other) => new()
+        {
+            Binary = Math.Nand(Binary, other.Binary)
+        };
+
+        public IncompleteDecimal Nand(Decimal other) => new()
+        {
+            Binary = Math.Nand(Binary, other.Binary)
+        };
+
+        public IncompleteDecimal Nor(IncompleteDecimal other) => new()
+        {
+            Binary = Math.Nor(Binary, other.Binary)
+        };
+
+        public IncompleteDecimal Nor(Decimal other) => new()
+        {
+            Binary = Math.Nor(Binary, other.Binary)
+        };
+
+        public IncompleteDecimal Xnor(IncompleteDecimal other) => new()
+        {
+            Binary = Math.Xnor(Binary, other.Binary)
+        };
+
+        public IncompleteDecimal Xnor(Decimal other) => new()
+        {
+            Binary = Math.Xnor(Binary, other.Binary)
+        };
+
+        public IncompleteDecimal ShiftLeft(int count) => new()
+        {
+            Binary = Binary.ShiftLeft(count)
+        };
+
+        public IncompleteDecimal ShiftRight(int count) => new()
+        {
+            Binary = Binary.ShiftRight(count)
+        };
+
         public bool ReverseAnd(Decimal right, out IncompleteDecimal result)
         {
             if (!Binary.CanReverseAnd(right.Binary))

--- a/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteDouble.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteDouble.cs
@@ -205,6 +205,46 @@ namespace NumeralSystems.Net.Type.Incomplete
             Binary = Binary.And(other.Binary)
         };
 
+        public IncompleteDouble Nand(IncompleteDouble other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteDouble Nand(Double other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteDouble Nor(IncompleteDouble other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteDouble Nor(Double other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteDouble Xnor(IncompleteDouble other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteDouble Xnor(Double other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteDouble ShiftLeft(int count) => new()
+        {
+            Binary = Binary.ShiftLeft(count)
+        };
+
+        public IncompleteDouble ShiftRight(int count) => new()
+        {
+            Binary = Binary.ShiftRight(count)
+        };
+
         /// <summary>
         /// Performs a reverse bitwise AND operation with the specified double.
         /// </summary>

--- a/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteFloat.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteFloat.cs
@@ -207,6 +207,46 @@ namespace NumeralSystems.Net.Type.Incomplete
             Binary = Binary.And(other.Binary)
         };
 
+        public IncompleteFloat Nand(IncompleteFloat other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteFloat Nand(Float other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteFloat Nor(IncompleteFloat other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteFloat Nor(Float other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteFloat Xnor(IncompleteFloat other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteFloat Xnor(Float other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteFloat ShiftLeft(int count) => new()
+        {
+            Binary = Binary.ShiftLeft(count)
+        };
+
+        public IncompleteFloat ShiftRight(int count) => new()
+        {
+            Binary = Binary.ShiftRight(count)
+        };
+
         /// <summary>
         /// Performs a reverse bitwise AND operation with the specified float.
         /// </summary>

--- a/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteInt.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteInt.cs
@@ -218,6 +218,46 @@ namespace NumeralSystems.Net.Type.Incomplete
             Binary = Binary.Or(other.Binary)
         };
 
+        public IncompleteInt Nand(IncompleteInt other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteInt Nand(Int other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteInt Nor(IncompleteInt other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteInt Nor(Int other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteInt Xnor(IncompleteInt other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteInt Xnor(Int other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteInt ShiftLeft(int count) => new()
+        {
+            Binary = Binary.ShiftLeft(count)
+        };
+
+        public IncompleteInt ShiftRight(int count) => new()
+        {
+            Binary = Binary.ShiftRight(count)
+        };
+
         /// <summary>
         /// Performs a reverse bitwise AND operation with the specified integer.
         /// </summary>

--- a/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteLong.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteLong.cs
@@ -212,6 +212,46 @@ namespace NumeralSystems.Net.Type.Incomplete
             Binary = Binary.And(other.Binary)
         };
 
+        public IncompleteLong Nand(IncompleteLong other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteLong Nand(Long other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteLong Nor(IncompleteLong other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteLong Nor(Long other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteLong Xnor(IncompleteLong other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteLong Xnor(Long other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteLong ShiftLeft(int count) => new()
+        {
+            Binary = Binary.ShiftLeft(count)
+        };
+
+        public IncompleteLong ShiftRight(int count) => new()
+        {
+            Binary = Binary.ShiftRight(count)
+        };
+
         /// <summary>
         /// Performs a reverse bitwise AND operation with the specified long integer.
         /// </summary>

--- a/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteShort.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteShort.cs
@@ -209,6 +209,46 @@ namespace NumeralSystems.Net.Type.Incomplete
             Binary = Binary.Or(other.Binary)
         };
 
+        public IncompleteShort Nand(IncompleteShort other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteShort Nand(Short other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteShort Nor(IncompleteShort other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteShort Nor(Short other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteShort Xnor(IncompleteShort other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteShort Xnor(Short other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteShort ShiftLeft(int count) => new()
+        {
+            Binary = Binary.ShiftLeft(count)
+        };
+
+        public IncompleteShort ShiftRight(int count) => new()
+        {
+            Binary = Binary.ShiftRight(count)
+        };
+
         /// <summary>
         /// Performs a reverse bitwise AND operation with the specified short integer.
         /// </summary>

--- a/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteUInt.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteUInt.cs
@@ -215,6 +215,46 @@ namespace NumeralSystems.Net.Type.Incomplete
             Binary = Binary.And(other.Binary)
         };
 
+        public IncompleteUInt Nand(IncompleteUInt other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteUInt Nand(UInt other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteUInt Nor(IncompleteUInt other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteUInt Nor(UInt other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteUInt Xnor(IncompleteUInt other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteUInt Xnor(UInt other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteUInt ShiftLeft(int count) => new()
+        {
+            Binary = Binary.ShiftLeft(count)
+        };
+
+        public IncompleteUInt ShiftRight(int count) => new()
+        {
+            Binary = Binary.ShiftRight(count)
+        };
+
         /// <summary>
         /// Performs a reverse bitwise AND operation with the specified unsigned integer.
         /// </summary>

--- a/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteULong.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteULong.cs
@@ -191,6 +191,46 @@ namespace NumeralSystems.Net.Type.Incomplete
             Binary = Binary.And(other.Binary)
         };
 
+        public IncompleteULong Nand(IncompleteULong other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteULong Nand(ULong other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteULong Nor(IncompleteULong other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteULong Nor(ULong other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteULong Xnor(IncompleteULong other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteULong Xnor(ULong other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteULong ShiftLeft(int count) => new()
+        {
+            Binary = Binary.ShiftLeft(count)
+        };
+
+        public IncompleteULong ShiftRight(int count) => new()
+        {
+            Binary = Binary.ShiftRight(count)
+        };
+
         /// <summary>
         /// Performs a reverse AND operation between the binary representation of the given ULong value and the binary representation of this IncompleteULong value.
         /// </summary>

--- a/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteUShort.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Type/Incomplete/IncompleteUShort.cs
@@ -212,6 +212,46 @@ namespace NumeralSystems.Net.Type.Incomplete
             Binary = Binary.Or(other.Binary)
         };
 
+        public IncompleteUShort Nand(IncompleteUShort other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteUShort Nand(UShort other) => new()
+        {
+            Binary = Binary.Nand(other.Binary)
+        };
+
+        public IncompleteUShort Nor(IncompleteUShort other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteUShort Nor(UShort other) => new()
+        {
+            Binary = Binary.Nor(other.Binary)
+        };
+
+        public IncompleteUShort Xnor(IncompleteUShort other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteUShort Xnor(UShort other) => new()
+        {
+            Binary = Binary.Xnor(other.Binary)
+        };
+
+        public IncompleteUShort ShiftLeft(int count) => new()
+        {
+            Binary = Binary.ShiftLeft(count)
+        };
+
+        public IncompleteUShort ShiftRight(int count) => new()
+        {
+            Binary = Binary.ShiftRight(count)
+        };
+
         /// <summary>
         /// Performs a bitwise reverse AND operation on the binary representations of two UShort objects.
         /// </summary>

--- a/NumeralSystems.Net/NumeralSystems.Net/Utils/Math/Nor.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Utils/Math/Nor.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace NumeralSystems.Net.Utils
+{
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    internal static partial class Math
+    {
+        public static bool Nor(this bool left, bool right) => !(left | right);
+        public static bool? Nor(this bool left, bool? right) => left.Or(right).Not();
+        public static bool? Nor(this bool? left, bool right) => left.Or(right).Not();
+        public static bool? Nor(this bool? left, bool? right) => left.Or(right).Not();
+        public static bool[] Nor(this bool[] left, bool[] right) => left.Or(right).Not();
+        public static bool?[] Nor(this bool[] left, bool?[] right) => left.Or(right).Not();
+        public static bool?[] Nor(this bool?[] left, bool[] right) => left.Or(right).Not();
+        public static bool?[] Nor(this bool?[] left, bool?[] right) => left.Or(right).Not();
+    }
+}

--- a/NumeralSystems.Net/NumeralSystems.Net/Utils/Math/ShiftLeft.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Utils/Math/ShiftLeft.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+
+namespace NumeralSystems.Net.Utils
+{
+    internal static partial class Math
+    {
+        public static bool[] ShiftLeft(this bool[] value, int count)
+        {
+            if (count <= 0) return value.ToArray();
+            if (count >= value.Length) return new bool[value.Length];
+            var result = new bool[value.Length];
+            for (var i = count; i < value.Length; i++)
+                result[i] = value[i - count];
+            return result;
+        }
+
+        public static bool?[] ShiftLeft(this bool?[] value, int count)
+        {
+            if (count <= 0) return value.ToArray();
+            if (count >= value.Length) return new bool?[value.Length];
+            var result = new bool?[value.Length];
+            for (var i = count; i < value.Length; i++)
+                result[i] = value[i - count];
+            return result;
+        }
+    }
+}

--- a/NumeralSystems.Net/NumeralSystems.Net/Utils/Math/ShiftRight.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Utils/Math/ShiftRight.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+
+namespace NumeralSystems.Net.Utils
+{
+    internal static partial class Math
+    {
+        public static bool[] ShiftRight(this bool[] value, int count)
+        {
+            if (count <= 0) return value.ToArray();
+            if (count >= value.Length) return new bool[value.Length];
+            var result = new bool[value.Length];
+            for (var i = 0; i < value.Length - count; i++)
+                result[i] = value[i + count];
+            return result;
+        }
+
+        public static bool?[] ShiftRight(this bool?[] value, int count)
+        {
+            if (count <= 0) return value.ToArray();
+            if (count >= value.Length) return new bool?[value.Length];
+            var result = new bool?[value.Length];
+            for (var i = 0; i < value.Length - count; i++)
+                result[i] = value[i + count];
+            return result;
+        }
+    }
+}

--- a/NumeralSystems.Net/NumeralSystems.Net/Utils/Math/Xnor.cs
+++ b/NumeralSystems.Net/NumeralSystems.Net/Utils/Math/Xnor.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace NumeralSystems.Net.Utils
+{
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    internal static partial class Math
+    {
+        public static bool Xnor(this bool left, bool right) => !(left ^ right);
+        public static bool? Xnor(this bool left, bool? right) => left.Xor(right).Not();
+        public static bool? Xnor(this bool? left, bool right) => left.Xor(right).Not();
+        public static bool? Xnor(this bool? left, bool? right) => left.Xor(right).Not();
+        public static bool[] Xnor(this bool[] left, bool[] right) => left.Xor(right).Not();
+        public static bool?[] Xnor(this bool[] left, bool?[] right) => left.Xor(right).Not();
+        public static bool?[] Xnor(this bool?[] left, bool[] right) => left.Xor(right).Not();
+        public static bool?[] Xnor(this bool?[] left, bool?[] right) => left.Xor(right).Not();
+    }
+}


### PR DESCRIPTION
## Summary
- extend `IIRregularOperable` with additional bitwise and shift methods
- implement `Nand`, `Nor`, `Xnor`, `ShiftLeft`, `ShiftRight` for incomplete numeric types
- support operations in math helpers
- add NUnit tests for the new operations

## Testing
- `dotnet test NumeralSystems.Net/NumeralSystem.Net.NUnit/NumeralSystem.Net.NUnit.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcbb3b58c832cb23d900ec6b926bc